### PR TITLE
Add myself to the list of core team members

### DIFF
--- a/index.md
+++ b/index.md
@@ -44,6 +44,7 @@ We appreciate all feedback from individuals on github.
 * [David Faust](https://github.com/dafaust)
 * [Wenzhang Yang](https://github.com/thomasyonug)
 * [Philipp Krones](https://github.com/flip1995)
+* [Owen Avery](https://github.com/powerboat9)
 
 ### Get Involved
 


### PR DESCRIPTION
I didn't realize until now that I wasn't listed on the website as a core team member -- would probably be a good idea to fix that, since I have it listed on my resume